### PR TITLE
Fixed auto-start on Rpi 4

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -83,7 +83,7 @@ inky.test()  # test if Inkycal can be run correctly, running this will show a bi
 inky.run()   # If there were no issues, you can run Inkycal nonstop
 EOF
         echo -e "\e[1;36m"Updating crontab"\e[0m"
-        (crontab -l ; echo "@reboot python3 /home/$USER/inky_run.py &")| crontab -
+        (crontab -l ; echo "@reboot sleep 60 && python3 /home/$USER/inky_run.py &")| crontab -
 	fi
 
     # Final words


### PR DESCRIPTION
The Raspberry Pi 4 had some issues in regards to Inkycal starting at boot. By adding a delay of 1 min to allow the Raspberry Pi to fully load, the issue gets fixed.
Special thanks to @Worstface for finding the issue and suggesting a solution.