### PR TITLE
Fix for KeyError: 31

### DIFF
--- a/inkycal/modules/inkycal_calendar.py
+++ b/inkycal/modules/inkycal_calendar.py
@@ -258,14 +258,15 @@ class Calendar(inkycal_module):
 
       # Draw a border with specified parameters around days with events
       for days in days_with_events:
-        draw_border(
-          im_colour,
-          grid[days],
-          (icon_width, icon_height),
-          radius = 6,
-          thickness= 1,
-          shrinkage = (0.4, 0.2)
-          )
+        if days in grid:
+          draw_border(
+            im_colour,
+            grid[days],
+            (icon_width, icon_height),
+            radius = 6,
+            thickness= 1,
+            shrinkage = (0.4, 0.2)
+            )
 
       # Filter upcoming events until 4 weeks in the future
       parser.clear_events()


### PR DESCRIPTION
Added a second check for checking if key exists in the dictionary.
This fixes #168 and has been tested by @hag2k. 