### PR TITLE
Weather Module: Windspeed rounding and formatting fix

### DIFF
--- a/inkycal/modules/inkycal_weather.py
+++ b/inkycal/modules/inkycal_weather.py
@@ -442,11 +442,11 @@ class Weather(inkycal_module):
 
       if self.units == 'metric':
         logging.debug('getting windspeed in metric unit')
-        wind = str(round(weather.wind(unit='meters_sec')['speed']), ndigits=dec_wind) + 'm/s'
+        wind = str(round(weather.wind(unit='meters_sec')['speed'], ndigits=dec_wind)) + ' m/s'
 
       elif self.units == 'imperial':
         logging.debug('getting windspeed in imperial unit')
-        wind = str(round(weather.wind(unit='miles_hour')['speed']), ndigits=dec_wind) + 'miles/h'
+        wind = str(round(weather.wind(unit='miles_hour')['speed'], ndigits=dec_wind)) + ' mph'
 
     dec = decimal.Decimal
     moonphase = get_moon_phase()

--- a/inkycal/modules/inkycal_weather.py
+++ b/inkycal/modules/inkycal_weather.py
@@ -442,11 +442,11 @@ class Weather(inkycal_module):
 
       if self.units == 'metric':
         logging.debug('getting windspeed in metric unit')
-        wind = str(weather.wind(unit='meters_sec')['speed']) + 'm/s'
+        wind = str(round(weather.wind(unit='meters_sec')['speed']), ndigits=dec_wind) + 'm/s'
 
       elif self.units == 'imperial':
         logging.debug('getting windspeed in imperial unit')
-        wind = str(weather.wind(unit='miles_hour')['speed']) + 'miles/h'
+        wind = str(round(weather.wind(unit='miles_hour')['speed']), ndigits=dec_wind) + 'miles/h'
 
     dec = decimal.Decimal
     moonphase = get_moon_phase()


### PR DESCRIPTION
I noticed that the non-beaufort wind speed in the weather module wasn't rounding at all, no matter how the _round_windspeed_ setting was set.  I was getting long wind speeds like _8.7264miles/h_, which would cut off before I could even see the text. With some quick changes, the non-beaufort wind speed now rounds like the temperature as expected.

Also, I made a couple of changes to the wind speed unit text to improve readability. Specifically, I:
- added a space before the wind speed units to make it a little more readable (i.e. _8 m/s_ instead of _8m/s_)
- changed _miles/h_ to _mph_, as the shorter abbreviation takes up less width and can fit better in the narrow boxes

Tested these changes in all 4 non-beaufort configurations and verified the following results:
- _metric rounded:_ no decimal place, units in m/s
- _metric unrounded:_ 1 decimal place, units in m/s
- _imperial rounded:_ no decimal place, units in mph
- _imperial unrounded:_ 1 decimal place, units in mph