### PR TITLE
Hotfix/arrow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ icalendar==4.0.6                # iCalendar parsing
 recurring-ical-events==0.1.17b0 # parse recurring events
 feedparser==5.2.1               # parse RSS-feeds
 numpy>=1.18.2                   # image pre-processing #pre-installed on Raspbian, omitting
-arrow>=0.15.6 	                # time operations
+arrow==0.17.0 	                # time operations
 Flask==1.1.2                    # webserver
 Flask-WTF==0.14.3               # webforms
 todoist-python==8.1.2           # todoist api

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ __install_requires__ = ['pyowm==3.1.1',                   # weather
                         'recurring-ical-events==0.1.17b0',# parse recurring events
                         'feedparser==5.2.1',              # RSS-feeds
                         # 'numpy>=1.18.2',                  # image pre-processing -> removed for issues with rpi os
-                        'arrow>=0.15.6',                  # time handling
+                        'arrow==0.17.0',                  # time handling
                         'Flask==1.1.2',                   # webserver
                         'Flask-WTF==0.14.3',              # webforms
                         'todoist-python==8.1.2',          # todoist api


### PR DESCRIPTION
Arrow v1.0.0 is not comptaible with Inkycal. The latest supported release is v0.17.0, but Inkycal has been downloading the latest release. As a measure to fix this dependency issue, the arrow version has been frozen to v0.17.0 with this hotfix.
For more details, please see #175 