### PR TITLE
fix 24h format for openweathermap hourly forecast

### DIFF
--- a/inkycal/modules/inkycal_weather.py
+++ b/inkycal/modules/inkycal_weather.py
@@ -361,7 +361,7 @@ class Weather(inkycal_module):
           'temp':temp,
           'icon':icon,
           'stamp': forecast_timings[forecasts.index(forecast)].to(
-            get_system_tz()).format('H.00' if self.hour_format == 24 else 'h a')
+            get_system_tz()).format('H:00' if self.hour_format == 24 else 'h a')
           }
 
     elif self.forecast_interval == 'daily':


### PR DESCRIPTION
As per #178 , 24h format for openweathermap is now consistent with the other instances in the same file.