### PR TITLE
Reworked Agenda to use less space

### DIFF
--- a/inkycal/custom/functions.py
+++ b/inkycal/custom/functions.py
@@ -8,6 +8,7 @@ Copyright by aceisace
 import logging
 from PIL import Image, ImageDraw, ImageFont, ImageColor
 from urllib.request import urlopen
+from urllib.error import URLError
 import os
 import time
 


### PR DESCRIPTION
This implementation collects all events starting on a date in a date item in order to use space more sparingly.

It creates a dictionary with all possible dates for the future and slots in the agenda items from the ical package. It allows for one additional entry per date and is a little less code. There is no longer a case distinction between an error in ical retrieval and success so fewer code paths. The drawing algorithm itself is the same and besides some variable renaming I kept it the same.

The issue that whole-day events spanning DST changes is shown with `00:00` is seperate (as you can see in both images)

Before:
![IMG_20210326_225300_267](https://user-images.githubusercontent.com/613272/112696903-fad5a780-8e86-11eb-908d-9aa1d8e58fad.jpg)

After:
![IMG_20210326_222911_839](https://user-images.githubusercontent.com/613272/112697012-117bfe80-8e87-11eb-975a-ddf33d763c40.jpg)
