### PR TITLE
Allow All-Day events to be less than a day (DST)

### DIFF
--- a/inkycal/modules/ical_parser.py
+++ b/inkycal/modules/ical_parser.py
@@ -17,6 +17,7 @@ import arrow
 from urllib.request import urlopen
 import logging
 import time
+from datetime import timedelta
 import os
 
 try:
@@ -179,7 +180,7 @@ class iCalendar:
       begin, end = event['begin'], event['end']
       duration = end - begin
       if (begin.format('HH:mm') == '00:00' and end.format('HH:mm') == '00:00'
-          and duration.days >= 1):
+          and duration > timedelta(hours=12)):
         return True
       else:
         return False


### PR DESCRIPTION
This allows for all-day events that are less than 24 hours, as they might fall between DST-changes

As we have seen in #184 , all-day-events aren't correctly identified when the event spans a timezone change such that the day has 23 instead of 24 hours.

Such an event would, for example span the following interval:
```
START: 2021-03-28T00:00:00+01:00
  END: 2021-03-29T00:00:00+02:00
  DUR: 23:00:00
```

The original algorithm already checked for the time-portion of the event. This change gives a little bit more leniency. This also allows for TZ changes of more than one hour. I think half a day is enough. Can't imagine a situation where an event is all day but less than 12 hours from 00:00 to 00:00. I guess something along the lines of `>=22 hours` would be fine as well. I am not aware of DST changes of more than 2 hours.

After the changes, we correctly see this (from the google calendar ical of german holidays)

![IMG_20210327_003552_118](https://user-images.githubusercontent.com/613272/112703009-bb628780-8e95-11eb-96a2-ebc7aabd97d2.jpg)

Edit: it seems that #161 maybe addresses similar issues. This here PR aims to be minimally invasive and is just there to fix the specific DST issue going from normal to summer time.
