### PR TITLE
agenda: print localized time for events

### DIFF
--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -196,7 +196,7 @@ class Agenda(inkycal_module):
 
         # Check if item is an event
         if 'end' in _:
-          time = _['begin'].format(self.time_format)
+          time = _['begin'].format(self.time_format, locale=self.language)
 
           # Check if event is all day, if not, add the time
           if parser.all_day(_) == False:


### PR DESCRIPTION
in before these were always formatted with the default locale

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>