### PR TITLE
Fixed parser reading file based calendars as strings rather than calendar objects

### DIFF
--- a/inkycal/modules/ical_parser.py
+++ b/inkycal/modules/ical_parser.py
@@ -78,12 +78,12 @@ class iCalendar:
             for path in filepath:
                 with open(path, mode='r') as ical_file:
                     ical = (Calendar.from_ical(ical_file.read()))
-                    self.icalendars += ical
+                    self.icalendars.append(ical)
 
         elif isinstance(filepath, str):
             with open(filepath, mode='r') as ical_file:
                 ical = (Calendar.from_ical(ical_file.read()))
-                self.icalendars += ical
+                self.icalendars.append(ical)
         else:
             raise Exception(f"Input: '{filepath}' is not a string or list!")
 


### PR DESCRIPTION
Fixing an issue where, when doing += on adding the calendar objects parsed from a file, python is typing it as a string / typing icalendars object as a list of strings. 
Changing it to .append(ical) fixes it and ensures that file based ics objects work.