### PR TITLE
Calendar module: BTC price on the Month name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,22 @@ sudo dpkg-reconfigure tzdata
 These commands expand the filesystem, enable SPI and set up the correct timezone on the Raspberry Pi. When running the last command, please select the continent you live in, press enter and then select the capital of the country you live in. Lastly, press enter.
 
 10. Change the password for the user pi by entering `passwd` in the Terminal, enter your current password, hit enter, then type your new password and press enter. Please note you will have to remember this password to access your Raspberry Pi.
-11. Follow the steps in `Installation` (see below) on how to install Inkycal.
+11. If needed, disable the green LEDs on a Raspberry Pi Zero. To permanently disable the lights, edit the boot config file using the following command:
+- Edit the file:
+```bash
+sudo nano /boot/config.txt
+```
+- Add in to the bottom:
+```bash
+# Disable the ACT LED on the Pi Zero
+dtparam=act_led_trigger=none
+dtparam=act_led_activelow=on
+```
+- Reboot the Pi:
+```bash
+sudo reboot
+```
+12. Follow the steps in `Installation` (see below) on how to install Inkycal.
 
 ### Installation
 Open a Terminal and enter the following command:

--- a/run_inkycal.py
+++ b/run_inkycal.py
@@ -1,0 +1,16 @@
+from inkycal import Inkycal
+
+"""
+    # If your settings.json file is not in /boot, use the full path:
+inky = Inkycal('path/to/settings.json', render=True)
+     
+    # Test if Inkycal can be run correctly, running this will show a bit of info for each module
+inky.test() 
+ 
+    # If there were no issues, you can run Inkycal nonstop
+inky.run()
+"""
+inky = Inkycal(render=False)
+
+#inky.test()
+inky.run()


### PR DESCRIPTION
I've found it very useful for me - to show the BTC price next to the month name (no need to use dedicated module for this purpose, simply use otherwise empty space next to the Month name). 
![image](https://user-images.githubusercontent.com/5597505/211200854-23ec3a58-3196-4767-8b6d-7d4585b3624b.png)

By default works as usual, if there are no dedicated settings in `settings.json` file for Calendar module:
```
        {
            "position": 2,
            "name": "Calendar",
            "config": {
                "size": [
                    528,
                    490
                ],
                "week_starts_on": "Monday",
                "show_events": true,
          ...
                 "language": "en",
                "show_btc_price_at_month_name": true,
                "coin_price_url": "https://api.coindesk.com/v1/bpi/currentprice.json"
            }
```
